### PR TITLE
Enclose build paths in double quotes. 

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -154,7 +154,7 @@ namespace R4nd0mApps.TddStud10.Engine
                     Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
                     string.Format(@"MSBuild\{0}\Bin\msbuild.exe", host.HostVersion)),
                 string.Format(
-                    @"/m /v:minimal /p:Configuration=Debug /p:CreateVsixContainer=false /p:DeployExtension=false /p:CopyVsixExtensionFiles=false /p:OutDir={1} {2}",
+                    @"/m /v:minimal /p:Configuration=Debug /p:CreateVsixContainer=false /p:DeployExtension=false /p:CopyVsixExtensionFiles=false /p:OutDir=""{1}\\"" ""{2}""",
                     host.HostVersion.ToString(),
                     rsp.Solution.BuildRoot.Item,
                     rsp.Solution.SnapshotPath.Item)


### PR DESCRIPTION
Enclose build paths in double quotes. Add trailing slash to OutDir which is a requirement of msbuild.

Relates to https://github.com/parthopdas/tddstud10/issues/20