### PR TITLE
ignore tests in tddstudio environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # User-specific files
 *.suo
 *.user
+!CSXUnit1xNUnit3x.sln.tddstud10.user
 *.userosscache
 *.sln.docstates
 
@@ -255,3 +256,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+

--- a/AcceptanceTests/AdapterTests/2_CSXUnit1xNUnit3x.NET20/CSXUnit1xNUnit3x.sln.tddstud10.user
+++ b/AcceptanceTests/AdapterTests/2_CSXUnit1xNUnit3x.NET20/CSXUnit1xNUnit3x.sln.tddstud10.user
@@ -1,0 +1,1 @@
+{  "IgnoredTests": "CSXUnit1xNUnit3x.StringTests3.TestToSkip",  "SnapShotRoot": "%temp%\\_tdd" }

--- a/AcceptanceTests/AdapterTests/2_CSXUnit1xNUnit3x.NET20/Class1.cs
+++ b/AcceptanceTests/AdapterTests/2_CSXUnit1xNUnit3x.NET20/Class1.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
+using Xunit;
 
 namespace CSXUnit1xNUnit3x
 {
@@ -29,6 +30,12 @@ namespace CSXUnit1xNUnit3x
 
             NUnit.Framework.Assert.That(sqrt >= 0.0);
             NUnit.Framework.Assert.That(sqrt * sqrt, NUnit.Framework.Is.EqualTo(num).Within(0.000001));
+        }
+
+        [Fact]
+        public void TestToSkip()
+        {
+            Assert.Equal(0, 0);
         }
     }
 

--- a/Common/Domain.UnitTests/Domain.UnitTests.fsproj
+++ b/Common/Domain.UnitTests/Domain.UnitTests.fsproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>b8c86b59-c6c4-459c-967a-5e8c0111c433</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Domain.UnitTests</RootNamespace>
+    <AssemblyName>Domain.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Domain.UnitTests</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Domain.UnitTests.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Domain.UnitTests.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <ProjectReference Include="..\Domain\Domain.fsproj">
+      <Name>Domain</Name>
+      <Project>{e5fb2293-1833-4c4c-800e-a31ac891a931}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.0\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Common/Domain/Domain.fsproj
+++ b/Common/Domain/Domain.fsproj
@@ -76,6 +76,9 @@
     <Compile Include="Code\CollectionExtensions.fs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.0\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
     <Reference Include="Clide">
       <HintPath>..\..\incr\packages\Clide.2.3.29\lib\net40\Clide.dll</HintPath>
       <Private>True</Private>

--- a/Common/Domain/RunDomain.fs
+++ b/Common/Domain/RunDomain.fs
@@ -26,7 +26,8 @@ type RunStartParams =
       StartTime : DateTime
       TestHostPath : FilePath
       Solution : SolutionPaths
-      DataFiles : RunDataFiles }
+      DataFiles : RunDataFiles
+      IgnoredTests : string }
 
 type RunStepInfo = 
     { name : RunStepName

--- a/Engine.Core.UnitTests/RunExecutorTests.fs
+++ b/Engine.Core.UnitTests/RunExecutorTests.fs
@@ -59,6 +59,7 @@ let ``Executor initialized RunData``() =
             { Path = slnFile
               SnapshotPath = ~~(ssRoot + @"\folder\file.sln")
               BuildRoot = ~~(ssRoot + @"\folder\out") }
+          IgnoredTests = ""
           DataFiles = 
               { SequencePointStore = ~~(ssRoot + @"\folder\out\Z_sequencePointStore.xml")
                 CoverageSessionStore = ~~(ssRoot + @"\folder\out\Z_coverageresults.xml")

--- a/Engine.Core/EngineConfig.fs
+++ b/Engine.Core/EngineConfig.fs
@@ -6,8 +6,14 @@ open System.Runtime.Serialization
 [<DataContract>]
 type EngineConfig() = 
     let mutable snapShotRoot = @"%temp%\_tdd"
+    let mutable ignoredTests = ""
     
     [<DataMember(IsRequired = false)>]
     member __.SnapShotRoot 
         with get () = snapShotRoot
         and set value = snapShotRoot <- value
+
+    [<DataMember(IsRequired = false)>]
+    member __.IgnoredTests 
+        with get () = ignoredTests
+        and set value = ignoredTests <- value

--- a/Engine.Core/RunStartParamsExtensions.fs
+++ b/Engine.Core/RunStartParamsExtensions.fs
@@ -25,6 +25,7 @@ module RunStartParamsExtensions =
                   { Path = solutionPath
                     SnapshotPath = PathBuilder.makeSlnSnapshotPath snapShotRoot solutionPath
                     BuildRoot = buildRoot }
+              IgnoredTests = cfg.IgnoredTests
               DataFiles = 
                   { SequencePointStore =
                         PathBuilder.combine [ buildRoot

--- a/Engine.Core/TestHost.fs
+++ b/Engine.Core/TestHost.fs
@@ -5,7 +5,7 @@ module TestHost =
     open R4nd0mApps.TddStud10.Common.Domain
 
     let buildCommandLine cmd (rsp : RunStartParams) =
-        sprintf "\"%s\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\""
+        sprintf "\"%s\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\" \"%O\""
             cmd
             rsp.Solution.BuildRoot
             rsp.DataFiles.CoverageSessionStore
@@ -16,3 +16,4 @@ module TestHost =
             rsp.Solution.Path
             rsp.Solution.SnapshotPath
             rsp.DataFiles.DiscoveredUnitDTestsStore
+            rsp.IgnoredTests

--- a/Engine/Instrumentation.cs
+++ b/Engine/Instrumentation.cs
@@ -7,6 +7,7 @@ using R4nd0mApps.TddStud10.Engine.Diagnostics;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -64,7 +65,7 @@ namespace R4nd0mApps.TddStud10
         {
             foreach (MethodDefinition meth in type.Methods)
             {
-                if (meth.Body == null || meth.Body.Instructions.Count <= 0)
+                if (IsMethodSkipped(meth))
                 {
                     continue;
                 }
@@ -218,7 +219,7 @@ namespace R4nd0mApps.TddStud10
         {
             foreach (MethodDefinition meth in type.Methods)
             {
-                if (meth.Body == null || meth.Body.Instructions.Count <= 0)
+                if (IsMethodSkipped(meth))
                 {
                     continue;
                 }
@@ -293,6 +294,11 @@ namespace R4nd0mApps.TddStud10
                 meth.Body.InitLocals = true;
                 meth.Body.OptimizeMacros();
             }
+        }
+
+        private static bool IsMethodSkipped(MethodDefinition meth)
+        {
+            return meth.Body == null || meth.Body.Instructions.Count <= 0;
         }
 
         private static void InjectExitUtCallInsideMethodWiseFinally(

--- a/FxCopCSharp.ruleset
+++ b/FxCopCSharp.ruleset
@@ -234,6 +234,8 @@
     <Rule Id="CA2242" Action="None" />
     <Rule Id="CA2243" Action="None" />
     <Rule Id="CA5122" Action="None" />
+    <Rule Id="CA904" Action="None" />
+    <Rule Id="CA908" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <Rule Id="C26100" Action="None" />

--- a/TddStud10.sln
+++ b/TddStud10.sln
@@ -52,6 +52,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AcceptanceTests", "Acceptan
 		AcceptanceTests\README.md = AcceptanceTests\README.md
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Domain.UnitTests", "Common\Domain.UnitTests\Domain.UnitTests.fsproj", "{B8C86B59-C6C4-459C-967A-5E8C0111C433}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +116,10 @@ Global
 		{0FEA2E86-4EE0-4FD8-949D-C74189B855D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FEA2E86-4EE0-4FD8-949D-C74189B855D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FEA2E86-4EE0-4FD8-949D-C74189B855D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8C86B59-C6C4-459C-967A-5E8C0111C433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8C86B59-C6C4-459C-967A-5E8C0111C433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8C86B59-C6C4-459C-967A-5E8C0111C433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8C86B59-C6C4-459C-967A-5E8C0111C433}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,5 +133,6 @@ Global
 		{C578A684-2FFF-4100-8620-C1220D05EA3E} = {F0EF1D07-83FA-47A9-9FB0-D17D59A9605D}
 		{E5FB2293-1833-4C4C-800E-A31AC891A931} = {ED5D34E1-9B51-4D56-8CB1-A1538EF3B8F4}
 		{0FEA2E86-4EE0-4FD8-949D-C74189B855D9} = {198AE2D4-84E6-491B-BCAA-FE9CD7E1A7B6}
+		{B8C86B59-C6C4-459C-967A-5E8C0111C433} = {ED5D34E1-9B51-4D56-8CB1-A1538EF3B8F4}
 	EndGlobalSection
 EndGlobal

--- a/TestHost.Core.UnitTests/XUnitTestDiscovererTests.fs
+++ b/TestHost.Core.UnitTests/XUnitTestDiscovererTests.fs
@@ -28,7 +28,7 @@ let createDiscoverer() =
 [<Fact>]
 let ``Can run successfully on assemblies with no tests``() = 
     let it, _ = createDiscoverer()
-    it.DiscoverTests([ ], testBin)
+    it.DiscoverTests([ ], testBin, Array.empty<string>)
 
 
 [<Fact>]
@@ -37,10 +37,28 @@ let ``Can discover theory and facts from test assembly``() =
     let td = 
         TestPlatformExtensions.getLocalPath() 
         |> TestPlatformExtensions.loadTestAdapter :?> ITestDiscoverer
-    it.DiscoverTests([ td ], testBin)
+    it.DiscoverTests([ td ], testBin, Array.empty<string>)
     let actualTests = 
         tcs
         |> Seq.map (fun t -> t.DisplayName)
         |> Seq.sort
         |> Seq.toList
     Assert.Equal<list<_>>(expectedTests, actualTests)
+
+[<Fact>]
+let ``Can ignore discover theory and facts from test assembly``() = 
+    let it, tcs = createDiscoverer()
+    let td = 
+        TestPlatformExtensions.getLocalPath() 
+        |> TestPlatformExtensions.loadTestAdapter :?> ITestDiscoverer
+    let filteredTestName = "XUnit20FSPortable.UnitTests.Theory Tests"
+   
+    it.DiscoverTests([ td ], testBin, [|filteredTestName|])
+    
+    let filteredTests = expectedTests |> List.filter (fun f -> f.StartsWith(filteredTestName) <> true)
+    let actualTests = 
+        tcs
+        |> Seq.map (fun t -> t.DisplayName)
+        |> Seq.sort
+        |> Seq.toList
+    Assert.Equal<list<_>>(filteredTests , actualTests)

--- a/TestHost.Core/XUnitTestDiscoverer.fs
+++ b/TestHost.Core/XUnitTestDiscoverer.fs
@@ -3,14 +3,22 @@
 open Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
 open R4nd0mApps.TddStud10.Common.Domain
 open R4nd0mApps.TddStud10.TestExecution
+open Microsoft.FSharp.Control
 
 type XUnitTestDiscoverer() = 
     let dc = TestPlatformExtensions.createDiscoveryContext()
     let ml = TestPlatformExtensions.createMessageLogger()
     let ds = TestPlatformExtensions.createDiscoverySink
-    let testDiscovered = new Event<_>()
-    member public __.TestDiscovered = testDiscovered.Publish
-    member public __.DiscoverTests(tds : ITestDiscoverer seq, FilePath asm) = 
+    let filteredTest = new Event<_>()
+    member public __.TestDiscovered = filteredTest.Publish
+    member public __.DiscoverTests(tds : ITestDiscoverer seq, FilePath asm, ignoredTests : string[]) = 
+        let testDiscovered = new Event<_>()
+        let handler = fun obj (testCase: Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase) -> 
+                            let exists = ignoredTests |> Array.exists (fun f -> testCase.FullyQualifiedName.StartsWith(f))
+                            match exists with
+                            | true -> ()
+                            | false -> filteredTest.Trigger(testCase)
+        testDiscovered.Publish.AddHandler(new Handler<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase>(handler))
         tds
         |> Seq.map (fun td -> td.DiscoverTests([ asm ], dc, ml, ds testDiscovered.Trigger))
         |> Seq.fold (fun _ -> id) ()

--- a/TestHost/Program.cs
+++ b/TestHost/Program.cs
@@ -13,8 +13,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.ServiceModel;
 using System.Threading.Tasks;
+using Mono.Cecil;
 
 namespace R4nd0mApps.TddStud10.TestHost
 {
@@ -58,12 +60,13 @@ namespace R4nd0mApps.TddStud10.TestHost
             var slnPath = args[7];
             var slnSnapPath = args[8];
             var discoveredUnitDTestsStore = args[9];
+            var ignoredTests = (args[10] ?? "").Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries);
 
             var searchPath = FilePath.NewFilePath(Path.Combine(Path.GetDirectoryName(slnSnapPath), "packages"));
             if (command == "discover")
             {
                 var tds = TestAdapterExtensions.findTestDiscoverers(TestAdapterExtensions.knownAdaptersMap).Invoke(searchPath);
-                DiscoverUnitTests(tds, slnPath, slnSnapPath, discoveredUnitTestsStore, discoveredUnitDTestsStore, buildRoot, new DateTime(long.Parse(timeFilter)));
+                DiscoverUnitTests(tds, slnPath, slnSnapPath, discoveredUnitTestsStore, discoveredUnitDTestsStore, buildRoot, new DateTime(long.Parse(timeFilter)), ignoredTests);
                 LogInfo("TestHost: Exiting Main.");
                 return 0;
             }
@@ -125,7 +128,7 @@ namespace R4nd0mApps.TddStud10.TestHost
                 });
         }
 
-        private static void DiscoverUnitTests(IEnumerable<ITestDiscoverer> tds, string slnPath, string slnSnapPath, string discoveredUnitTestsStore, string discoveredUnitDTestsStore, string buildOutputRoot, DateTime timeFilter)
+        private static void DiscoverUnitTests(IEnumerable<ITestDiscoverer> tds, string slnPath, string slnSnapPath, string discoveredUnitTestsStore, string discoveredUnitDTestsStore, string buildOutputRoot, DateTime timeFilter, string[] ignoredTests)
         {
             Logger.I.LogInfo("DiscoverUnitTests: starting discovering.");
             var testsPerAssembly = new PerDocumentLocationTestCases();
@@ -135,7 +138,6 @@ namespace R4nd0mApps.TddStud10.TestHost
                 timeFilter,
                 (string assemblyPath) =>
                 {
-                    var asmPath = FilePath.NewFilePath(assemblyPath);
                     var disc = new XUnitTestDiscoverer();
                     disc.TestDiscovered.AddHandler(
                         new FSharpHandler<TestCase>(
@@ -149,7 +151,7 @@ namespace R4nd0mApps.TddStud10.TestHost
                                 var dtests = dtestsPerAssembly.GetOrAdd(dl, _ => new ConcurrentBag<DTestCase>());
                                 dtests.Add(TestPlatformExtensions.toDTestCase(ea));
                             }));
-                    disc.DiscoverTests(tds, FilePath.NewFilePath(assemblyPath));
+                    disc.DiscoverTests(tds, FilePath.NewFilePath(assemblyPath), ignoredTests);
                 });
 
             testsPerAssembly.Serialize(FilePath.NewFilePath(discoveredUnitTestsStore));

--- a/TestHost/TestHost.csproj
+++ b/TestHost/TestHost.csproj
@@ -67,6 +67,9 @@
       <SpecificVersion>True</SpecificVersion>
       <HintPath>..\VSSDK.References\Vs2013\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.0\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />


### PR DESCRIPTION
There are two parts to this change. 
Scenario:
If the user wants some tests to be ignored to be anaylysed by tddstudio, he can put a ConditonalAttribute("TddStud10Ignore") on the specific test methods.

1. On doing that TddStudio will skip analysing the specific test methods. The red/green glyphs will not be shown. There is an additional advantage of tddstudio doing lesser work of analysing sequencePoints for this method.
2. TddStudio will not calculate coverage and wont execute the tests. Hence even if the tests are failing, the Build test cycle will stay green. Afterall that is what the user wanted.